### PR TITLE
Add GitHub Skills activity to course offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of GitHub Certifications program to help with college applications",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal but wasn't available for student registration.

## Changes
- Added "GitHub Skills" activity to the activities database
- Description highlights it's part of the GitHub Certifications program for college applications
- Schedule: Thursdays, 3:30 PM - 5:00 PM
- Max participants: 25 (to accommodate expected high demand)
- Starting with empty participant list

## Why This is Urgent
As noted in issue #6, this is time-sensitive - registration closes by the end of this week and many students are eager to join.

Fixes #6

## Testing
- ✅ Python syntax check passed
- ✅ Follows the same data structure as existing activities
- ✅ Ready for immediate deployment